### PR TITLE
Fix some environment variables

### DIFF
--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -61,12 +61,16 @@ spec:
           value: {{ .Values.zookeeper.hosts | quote }}
         {{- end }}
         {{- else if .Values.kubernetesDCS.enable }}
+        - name: DCS_ENABLE_KUBERNETES_API
+          value: {{ .Values.kubernetesDCS.enable | quote }}
         - name: PATRONI_KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: PATRONI_KUBERNETES_LABELS
-          value: '{app: {{ template "patroni.name" . }},release: {{ .Release.Name }} }'
+        - name: KUBERNETES_LABELS
+          value: '{"app": "{{ template "patroni.name" . }}", "release": "{{ .Release.Name }}"}'
+        - name: KUBERNETES_SCOPE_LABEL
+          value: release
         {{- end }}
         - name: SCOPE
           value: {{ template "patroni.fullname" . }}


### PR DESCRIPTION
 * `DCS_ENABLE_KUBERNETES_API` is required to be set to true

 * `PATRONI_KUBERNETES_LABELS` does nothing, me must use
   `KUBERNETES_LABELS` instead. It must also be a valid JSON string.

 * `KUBERNETES_SCOPE_LABEL` must be set to "release" to match what
    created by helm

Signed-off-by: Marco Nenciarini <marco.nenciarini@2ndquadrant.it>